### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Services Overview
+
+| Service | Command | Port |
+|---------|---------|------|
+| PostGIS (Docker) | `docker compose -f docker-compose.local.yml up -d` | 5433 |
+| Django Backend | `cd maplocation && source ../venv/bin/activate && python3 manage.py runserver 0.0.0.0:8000` | 8000 |
+| Vue Frontend | `cd map-frontend && ./switch-env.sh dev && npm run dev -- --host 0.0.0.0` | 3000 |
+
+### Environment Variables for Django
+
+Before running Django commands, export these:
+
+```
+export DB_NAME=chla_local DB_USER=chla_dev DB_PASSWORD=dev_password DB_HOST=localhost DB_PORT=5433 DJANGO_DEBUG=true
+```
+
+### Key Gotchas
+
+- **Docker daemon**: Must start `dockerd` manually on each VM boot (`sudo dockerd &>/tmp/dockerd.log &`) and fix socket permissions (`sudo chmod 666 /var/run/docker.sock`).
+- **pgvector extension**: The PostGIS Docker image does not include pgvector by default. After the container starts, install it: `docker exec chla-postgres-local bash -c "apt-get update && apt-get install -y postgresql-16-pgvector"` then `docker exec chla-postgres-local psql -U chla_dev -d chla_local -c "CREATE EXTENSION IF NOT EXISTS vector;"`.
+- **Migration 0026**: On a fresh database, migration `0026_delete_provider` fails because the `providers` table was already dropped in migration 0022. Workaround: `python3 manage.py migrate locations 0026_delete_provider --fake` then `python3 manage.py migrate`.
+- **Backend tests**: Tests require `pytest`, `pytest-django`, and `pytest-cov`. Some tests have pre-existing failures due to outdated fixtures (e.g., referencing removed model fields like `accepts_insurance`).
+- **Frontend tests**: Some vitest tests have pre-existing failures unrelated to environment setup.
+- **Basic Auth**: The admin/client portal is behind Basic Auth (username: `clientaccess`, password: `changeme123!`) before Django login.
+
+### Standard Commands
+
+- **Lint/check (backend)**: `python3 manage.py check` and `python3 -m compileall -q .`
+- **Lint/check (frontend)**: See `package.json` — no dedicated lint script beyond build validation.
+- **Tests (backend)**: `cd maplocation && python3 -m pytest locations/tests/ -v`
+- **Tests (frontend)**: `cd map-frontend && npx vitest run`
+- **Build (frontend)**: `cd map-frontend && npm run build`
+- **Quick pre-commit check**: `./scripts/quick-test.sh`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development environment instructions for future agents.

### What's included

- Service overview table (PostGIS, Django, Vue frontend) with ports and startup commands
- Required environment variables for Django
- Key gotchas discovered during setup:
  - Docker daemon must be started manually on VM boot
  - pgvector extension must be installed in the PostGIS container
  - Migration 0026 needs to be faked on fresh databases
  - Pre-existing test failures in both backend and frontend
- Standard commands for lint, test, build, and pre-commit checks

### Demo

[chla_provider_map_demo.mp4](https://cursor.com/agents/bc-0532465a-6e24-4ade-baeb-ab95868c738e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchla_provider_map_demo.mp4)

Application running with all services healthy (21 regional centers loaded, map interactive, admin panel accessible).

[CHLA Provider Map main view](https://cursor.com/agents/bc-0532465a-6e24-4ade-baeb-ab95868c738e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_main_view.webp)
[Django admin panel](https://cursor.com/agents/bc-0532465a-6e24-4ade-baeb-ab95868c738e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_panel.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0532465a-6e24-4ade-baeb-ab95868c738e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0532465a-6e24-4ade-baeb-ab95868c738e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

