### PR TITLE
Fix frontend deployment prerender install

### DIFF
--- a/map-frontend/package.json
+++ b/map-frontend/package.json
@@ -37,10 +37,6 @@
     "vitest": "^4.0.3"
   },
   "overrides": {
-    "vite-plugin-prerender": {
-      "@prerenderer/renderer-puppeteer": {
-        "puppeteer": "$puppeteer"
-      }
-    }
+    "puppeteer": "$puppeteer"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Correct the npm override so `@prerenderer/renderer-puppeteer` dedupes to the app's declared Puppeteer version.
- Prevent the production frontend deployment from installing the legacy Puppeteer 1.x transitive dependency that caused `npm ci` failures and prerender hangs.

## Verification
- `cd map-frontend && npm ci`
- `cd map-frontend && npm ls puppeteer`
- `cd map-frontend && npm run build`
- `. .venv/bin/activate && ./scripts/test-deployment-locally.sh` reached and passed Python syntax, Django deploy check, requirements dry-run, frontend production build, and EB config checks.

## Remaining local-only pre-flight blockers
- The full local pre-flight still reports missing root `.env.production` and missing AWS profile `personal` in this Cloud VM. The active GitHub production workflow creates `map-frontend/.env.production` from Actions secrets and configures AWS credentials via `aws-actions/configure-aws-credentials`, so these are not the frontend install/build blocker from the failed production runs.

## Notes
- The latest failed production workflow was blocked in the frontend install/build step because `npm ci` could not reconcile the package graph with the previous nested Puppeteer override.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-378923c0-5a26-49f7-bfbf-ea1d79d3a4d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-378923c0-5a26-49f7-bfbf-ea1d79d3a4d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

