### PR TITLE
Update privacy policy for Android, Google Maps, and AI

### DIFF
--- a/FIXES.md
+++ b/FIXES.md
@@ -1,0 +1,22 @@
+# FIXES.md — append-only change log (CHLA)
+
+Newest first. Every fix/feature/behavior change gets an entry; refactors and
+docs-only changes are exempt. On merge conflict: keep all entries, newest first.
+
+Format:
+
+### YYYY-MM-DD — short title
+- **Branch:** feat/slug
+- **Files:** path/one, path/two
+- **Problem:** one or two lines
+- **Fix:** one or two lines
+
+---
+
+### 2026-07-22 — Privacy policy covers Android, Google Maps, and AI
+- **Branch:** chore/privacy-policy-android
+- **Files:** map-frontend/src/views/PrivacyPolicyView.vue, map-frontend/src/views/TermsOfServiceView.vue, map-frontend/src/seo/siteConfig.js
+- **Problem:** Public privacy page still described Apple Maps/Mapbox only, omitted AI/data disclosures needed for Play submission, and used privacy@ instead of support@.
+- **Fix:** Rewrote the /privacy page for iOS + Android + web, added Google Maps and AWS Bedrock/Ask KiNDD disclosures, and set contact email to support@kinddhelp.org.
+
+---

--- a/map-frontend/src/seo/siteConfig.js
+++ b/map-frontend/src/seo/siteConfig.js
@@ -88,7 +88,7 @@ const ROUTE_SEO = {
   '/privacy': {
     title: `Privacy Policy - ${SITE_TITLE}`,
     description:
-      'Privacy policy for KiNDD - NDD Resource Map. Learn how user information is handled.',
+      'Privacy policy for the KiNDD website, iOS app, and Android app. Learn how location, AI chat, and other user information is handled.',
   },
   '/terms': {
     title: `Terms of Service - ${SITE_TITLE}`,

--- a/map-frontend/src/views/PrivacyPolicyView.vue
+++ b/map-frontend/src/views/PrivacyPolicyView.vue
@@ -3,17 +3,25 @@
     <div class="container">
       <header class="policy-header">
         <h1>Privacy Policy</h1>
-        <p class="last-updated">Last Updated: December 15, 2025</p>
+        <p class="last-updated">Last Updated: July 22, 2026</p>
       </header>
 
       <div class="policy-content">
         <section>
           <h2>Introduction</h2>
           <p>
-            NDD Resource Map ("we," "our," or "us") is committed to protecting
-            your privacy. This Privacy Policy explains how we collect, use, and
-            safeguard your information when you use our mobile application and
-            website (collectively, the "Service").
+            KiNDD - NDD Resource Navigator ("KiNDD," "we," "our," or "us") is
+            committed to protecting your privacy. This Privacy Policy explains
+            how we collect, use, and safeguard your information when you use our
+            website and our mobile applications for iOS and Android
+            (collectively, the "Service").
+          </p>
+          <p>
+            This policy applies to all platforms on which KiNDD is offered. It
+            is published as a publicly accessible web page (not a PDF) at
+            <a href="https://kinddhelp.org/privacy"
+              >https://kinddhelp.org/privacy</a
+            >.
           </p>
         </section>
 
@@ -33,9 +41,29 @@
             <li>Distance calculations to nearby providers</li>
           </ul>
           <p>
-            <strong>You can deny location access</strong> and still use all
-            features of the app. Without location access, you can search for
-            providers by ZIP code, city, or address.
+            <strong>You can deny location access</strong> and still use the
+            Service. Without location access, you can search for providers by
+            ZIP code, city, or address.
+          </p>
+
+          <h3>Account and Profile Information You Provide</h3>
+          <p>
+            Depending on the features you use, you may choose to provide
+            information such as:
+          </p>
+          <ul>
+            <li>ZIP code or other location search terms</li>
+            <li>
+              Optional care context (for example, child's age range, diagnosis
+              category, insurance type, journey stage, or current services)
+            </li>
+            <li>Language preference and accessibility preferences</li>
+            <li>Messages you send to the Ask KiNDD AI assistant</li>
+            <li>Support emails or feedback you send us</li>
+          </ul>
+          <p>
+            On mobile apps, some of this profile and chat information may be
+            stored on your device so the Service can remember your preferences.
           </p>
 
           <h3>Usage Data</h3>
@@ -44,11 +72,60 @@
             interact with our Service, including:
           </p>
           <ul>
-            <li>Pages and features you access</li>
+            <li>Pages, screens, and features you access</li>
             <li>Search queries you enter</li>
             <li>Time spent on the Service</li>
-            <li>Device type and operating system</li>
+            <li>Device type, operating system, and app version</li>
+            <li>
+              Approximate technical diagnostics needed to operate and improve
+              the Service
+            </li>
           </ul>
+        </section>
+
+        <section>
+          <h2>AI Assistant (Ask KiNDD)</h2>
+          <p>
+            The Service includes an optional AI assistant ("Ask KiNDD") that
+            helps you navigate regional center and related NDD resource
+            information. When you use Ask KiNDD:
+          </p>
+          <ul>
+            <li>
+              Your chat messages, and any optional profile context you have
+              provided (such as ZIP code, age range, diagnosis category,
+              insurance, or journey stage), are sent to our servers so we can
+              generate a response.
+            </li>
+            <li>
+              Responses are generated using third-party large language models
+              hosted through Amazon Web Services (AWS) Bedrock (currently
+              Anthropic Claude models). Those providers process the content
+              needed to generate the reply under our configuration and their
+              applicable terms.
+            </li>
+            <li>
+              We may use retrieval against our curated provider and regional
+              center information so answers can reference relevant resources.
+            </li>
+            <li>
+              Ask KiNDD is navigation and educational support only. It does
+              <strong>not</strong> provide medical advice, diagnosis, or
+              treatment instructions, and it is not a substitute for a qualified
+              clinician or your regional center.
+            </li>
+            <li>
+              Please do not include sensitive personal health information you do
+              not want processed by our systems or AI providers. Prefer general
+              descriptions over names, medical record numbers, or other
+              identifiers.
+            </li>
+          </ul>
+          <p>
+            You can clear on-device chat history in the app where that control
+            is available. Clearing chat on your device does not necessarily
+            delete operational logs already created on our servers.
+          </p>
         </section>
 
         <section>
@@ -56,10 +133,15 @@
           <p>We use the information we collect to:</p>
           <ul>
             <li>Show you healthcare resources near your location</li>
-            <li>Provide directions to service providers</li>
+            <li>Provide maps and directions to service providers</li>
+            <li>
+              Power Ask KiNDD responses and related resource recommendations
+            </li>
+            <li>Remember preferences you choose to save in the app</li>
             <li>Improve and optimize our Service</li>
             <li>Respond to your inquiries and support requests</li>
             <li>Analyze usage patterns to enhance user experience</li>
+            <li>Maintain security, reliability, and abuse prevention</li>
           </ul>
         </section>
 
@@ -71,8 +153,9 @@
           </p>
           <ul>
             <li>
-              With service providers who assist in operating our Service (e.g.,
-              hosting, analytics)
+              With service providers who assist in operating our Service (for
+              example, hosting, mapping, AI model inference, and analytics),
+              subject to appropriate contractual and technical safeguards
             </li>
             <li>When required by law or to protect our legal rights</li>
             <li>In connection with a merger, acquisition, or sale of assets</li>
@@ -90,42 +173,80 @@
         </section>
 
         <section>
-          <h2>Your Rights</h2>
+          <h2>Your Rights and Choices</h2>
           <p>You have the right to:</p>
           <ul>
             <li>Access the personal information we hold about you</li>
             <li>Request correction of inaccurate information</li>
             <li>Request deletion of your information</li>
             <li>
-              Withdraw consent for location tracking at any time through your
+              Withdraw consent for location access at any time through your
               device settings
             </li>
+            <li>
+              Decline optional profile details and still use many Service
+              features
+            </li>
+            <li>
+              Clear on-device chat history and profile data using in-app
+              controls where available
+            </li>
           </ul>
+          <p>
+            To make a privacy request, contact us at
+            <a href="mailto:support@kinddhelp.org">support@kinddhelp.org</a>.
+          </p>
         </section>
 
         <section>
           <h2>Third-Party Services</h2>
-          <p>Our Service may use the following third-party services:</p>
+          <p>
+            Our Service may use the following third-party services, depending on
+            the platform:
+          </p>
           <ul>
             <li>
-              <strong>Apple Maps / MapKit</strong> - For displaying maps and
-              providing directions
+              <strong>Apple Maps / MapKit</strong> — maps and directions on the
+              iOS app
             </li>
-            <li><strong>Mapbox</strong> - For map visualization on the web</li>
+            <li>
+              <strong>Google Maps / Google Play services</strong> — maps,
+              location, and directions on the Android app
+            </li>
+            <li>
+              <strong>Mapbox</strong> — map visualization and related location
+              services on the website
+            </li>
+            <li>
+              <strong>Amazon Web Services (AWS), including Bedrock</strong> —
+              hosting and AI model inference for Ask KiNDD
+            </li>
           </ul>
           <p>
-            These services have their own privacy policies governing the use of
-            your information.
+            These services have their own privacy policies governing their use
+            of information. Location data shared with mapping providers is used
+            to display maps, calculate distances, and provide directions.
           </p>
         </section>
 
         <section>
           <h2>Children's Privacy</h2>
           <p>
-            Our Service is not directed to children under the age of 13. We do
-            not knowingly collect personal information from children under 13.
-            If you believe we have collected information from a child under 13,
-            please contact us.
+            Our Service is intended for parents, caregivers, and adults seeking
+            NDD resource navigation help. It is not directed to children under
+            the age of 13, and we do not knowingly collect personal information
+            from children under 13. If you believe we have collected information
+            from a child under 13, please contact us so we can delete it.
+          </p>
+        </section>
+
+        <section>
+          <h2>International Users</h2>
+          <p>
+            The Service is operated from the United States. If you access the
+            Service from another country, your information may be processed in
+            the United States, where laws may differ from those in your
+            jurisdiction.
           </p>
         </section>
 
@@ -145,9 +266,13 @@
             practices, please contact us at:
           </p>
           <p class="contact-info">
-            <strong>Email:</strong> privacy@kinddhelp.org<br />
-            <strong>Website:</strong>
-            <a href="https://kinddhelp.org">https://kinddhelp.org</a>
+            <strong>Email:</strong>
+            <a href="mailto:support@kinddhelp.org">support@kinddhelp.org</a
+            ><br />
+            <strong>Privacy Policy URL:</strong>
+            <a href="https://kinddhelp.org/privacy"
+              >https://kinddhelp.org/privacy</a
+            >
           </p>
         </section>
       </div>

--- a/map-frontend/src/views/TermsOfServiceView.vue
+++ b/map-frontend/src/views/TermsOfServiceView.vue
@@ -3,7 +3,7 @@
     <div class="container">
       <header class="terms-header">
         <h1>Terms of Service</h1>
-        <p class="last-updated">Last Updated: December 15, 2025</p>
+        <p class="last-updated">Last Updated: July 22, 2026</p>
       </header>
 
       <div class="terms-content">
@@ -89,10 +89,10 @@
         <section>
           <h2>Third-Party Services</h2>
           <p>
-            The Service integrates with third-party mapping services (Apple
-            Maps, Mapbox) to provide location and directions features. Your use
-            of these features is subject to the respective third-party terms of
-            service.
+            The Service integrates with third-party mapping services (Apple Maps
+            on iOS, Google Maps on Android, and Mapbox on the web) and may use
+            cloud AI providers to power Ask KiNDD. Your use of these features is
+            subject to the respective third-party terms of service.
           </p>
         </section>
 


### PR DESCRIPTION
## Summary
- Rewrites the public `/privacy` page for website + iOS + Android (HTML page, not PDF/homepage)
- Adds Google Maps / Play services, AWS Bedrock / Ask KiNDD disclosures, and sets contact to `support@kinddhelp.org`
- Aligns Terms third-party language and SEO description with the same platforms

## Test plan
- [ ] After merge/deploy, open https://kinddhelp.org/privacy and confirm Last Updated is July 22, 2026
- [ ] Confirm Google Maps, Ask KiNDD/Bedrock, and `support@kinddhelp.org` appear on the page
- [ ] Confirm page is HTML (not PDF) and loads without login
- [ ] Use that URL in Play Console Data safety / privacy policy field