### PR TITLE
Invalidate both .com and .org CloudFront on deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -28,7 +28,10 @@ env:
   AWS_REGION: us-west-2
   EB_ENVIRONMENT: chla-api-docker2
   S3_BUCKET: kinddhelp-frontend-1755148345
+  # kinddhelp.com / www.kinddhelp.com (redirects canonical traffic to .org)
   CLOUDFRONT_DIST_ID: E2W6EECHUV4LMM
+  # kinddhelp.org / www.kinddhelp.org (canonical public site)
+  CLOUDFRONT_DIST_ID_ORG: E2Z6DZAF6O77HY
 
 jobs:
   deploy-backend:
@@ -138,13 +141,17 @@ jobs:
 
       - name: Invalidate CloudFront Cache
         run: |
-          echo "Invalidating CloudFront cache..."
-          INVALIDATION_ID=$(aws cloudfront create-invalidation \
-            --distribution-id ${{ env.CLOUDFRONT_DIST_ID }} \
-            --paths "/*" \
-            --query 'Invalidation.Id' \
-            --output text)
-          echo "CloudFront invalidation created: $INVALIDATION_ID"
+          echo "Invalidating CloudFront caches for .com and .org..."
+          for DIST_ID in \
+            "${{ env.CLOUDFRONT_DIST_ID }}" \
+            "${{ env.CLOUDFRONT_DIST_ID_ORG }}"; do
+            INVALIDATION_ID=$(aws cloudfront create-invalidation \
+              --distribution-id "$DIST_ID" \
+              --paths "/*" \
+              --query 'Invalidation.Id' \
+              --output text)
+            echo "CloudFront invalidation created for $DIST_ID: $INVALIDATION_ID"
+          done
           echo "Cache invalidation usually takes 1-2 minutes"
 
       - name: Verify Frontend
@@ -152,12 +159,12 @@ jobs:
           echo "Waiting for CloudFront propagation..."
           sleep 10
 
-          echo "Testing frontend..."
-          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" https://kinddhelp.com)
+          echo "Testing canonical frontend (kinddhelp.org)..."
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" https://kinddhelp.org)
           if [ "$STATUS_CODE" == "200" ]; then
-            echo "Frontend is accessible (HTTP $STATUS_CODE)"
+            echo "Frontend is accessible at kinddhelp.org (HTTP $STATUS_CODE)"
           else
-            echo " Frontend returned HTTP $STATUS_CODE (may need cache time)"
+            echo "Frontend returned HTTP $STATUS_CODE at kinddhelp.org (may need cache time)"
           fi
 
   deployment-summary:
@@ -177,7 +184,7 @@ jobs:
           echo "Backend Status: ${{ needs.deploy-backend.result }}"
           echo "Frontend Status: ${{ needs.deploy-frontend.result }}"
           echo ""
-          echo "Frontend URL: https://kinddhelp.com"
+          echo "Frontend URL: https://kinddhelp.org"
           echo "Backend API: https://api.kinddhelp.com"
           echo ""
           echo "════════════════════════════════════════════════════════════"

--- a/FIXES.md
+++ b/FIXES.md
@@ -13,6 +13,12 @@ Format:
 
 ---
 
+### 2026-07-22 — Invalidate both .com and .org CloudFront on deploy
+- **Branch:** fix/cloudfront-org-invalidation
+- **Files:** .github/workflows/deploy-production.yml, map-frontend/deploy.sh
+- **Problem:** Production deploy only invalidated the kinddhelp.com CloudFront dist; kinddhelp.com redirects to kinddhelp.org, which kept serving stale HTML until a manual invalidation.
+- **Fix:** Invalidate both E2W6EECHUV4LMM (.com) and E2Z6DZAF6O77HY (.org) after S3 sync, and verify the canonical .org URL.
+
 ### 2026-07-22 — Privacy policy covers Android, Google Maps, and AI
 - **Branch:** chore/privacy-policy-android
 - **Files:** map-frontend/src/views/PrivacyPolicyView.vue, map-frontend/src/views/TermsOfServiceView.vue, map-frontend/src/seo/siteConfig.js

--- a/map-frontend/deploy.sh
+++ b/map-frontend/deploy.sh
@@ -7,7 +7,8 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 S3_BUCKET="kinddhelp-frontend-1755148345"
-CLOUDFRONT_DIST_ID="E2W6EECHUV4LMM"
+CLOUDFRONT_DIST_ID="E2W6EECHUV4LMM"       # kinddhelp.com
+CLOUDFRONT_DIST_ID_ORG="E2Z6DZAF6O77HY"   # kinddhelp.org (canonical)
 AWS_PROFILE="personal"
 
 echo "Starting Frontend Deployment to Production..."
@@ -46,26 +47,27 @@ fi
 echo " Deployed to S3 successfully"
 echo ""
 
-# Step 4: Invalidate CloudFront cache
-echo "4 Invalidating CloudFront cache..."
-INVALIDATION_ID=$(AWS_PROFILE=$AWS_PROFILE aws cloudfront create-invalidation \
-    --distribution-id $CLOUDFRONT_DIST_ID \
-    --paths "/*" \
-    --query 'Invalidation.Id' \
-    --output text)
-
-if [ $? -ne 0 ]; then
-    echo " CloudFront invalidation failed!"
-    exit 1
-fi
-echo " CloudFront invalidation created: $INVALIDATION_ID"
+# Step 4: Invalidate CloudFront caches (.com and canonical .org)
+echo "4 Invalidating CloudFront caches..."
+for DIST_ID in "$CLOUDFRONT_DIST_ID" "$CLOUDFRONT_DIST_ID_ORG"; do
+    INVALIDATION_ID=$(AWS_PROFILE=$AWS_PROFILE aws cloudfront create-invalidation \
+        --distribution-id "$DIST_ID" \
+        --paths "/*" \
+        --query 'Invalidation.Id' \
+        --output text)
+    if [ $? -ne 0 ]; then
+        echo " CloudFront invalidation failed for $DIST_ID!"
+        exit 1
+    fi
+    echo " CloudFront invalidation created for $DIST_ID: $INVALIDATION_ID"
+done
 echo ""
 
 # Step 5: Verify deployment
 echo "5 Verifying deployment..."
 sleep 5
-echo " Testing frontend: https://kinddhelp.com"
-STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" https://kinddhelp.com)
+echo " Testing canonical frontend: https://kinddhelp.org"
+STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" https://kinddhelp.org)
 if [ "$STATUS_CODE" == "200" ]; then
     echo " Frontend is accessible (HTTP $STATUS_CODE)"
 else
@@ -75,8 +77,8 @@ echo ""
 
 echo "Deployment Complete!"
 echo ""
-echo "Frontend URL: https://kinddhelp.com"
-echo "CloudFront Distribution: $CLOUDFRONT_DIST_ID"
+echo "Frontend URL: https://kinddhelp.org"
+echo "CloudFront Distributions: $CLOUDFRONT_DIST_ID (.com), $CLOUDFRONT_DIST_ID_ORG (.org)"
 echo "S3 Bucket: $S3_BUCKET"
 echo ""
 echo "Note: CloudFront cache invalidation may take 1-2 minutes to propagate."


### PR DESCRIPTION
## Summary
- Production frontend deploy now invalidates both CloudFront distributions: `E2W6EECHUV4LMM` (kinddhelp.com) and `E2Z6DZAF6O77HY` (kinddhelp.org)
- Local `map-frontend/deploy.sh` matches that behavior
- Verify step checks the canonical `kinddhelp.org` URL

## Test plan
- [ ] Confirm workflow YAML lists both dist IDs
- [ ] On next frontend deploy, Actions log shows two invalidation IDs
- [ ] Updated pages appear on https://kinddhelp.org without a manual invalidation