### PR TITLE
Replace Resources loading spinner with skeleton cards

### DIFF
--- a/FIXES.md
+++ b/FIXES.md
@@ -13,6 +13,12 @@ Format:
 
 ---
 
+### 2026-08-13 — Skeleton loading state for the iOS Resources list
+- **Branch:** fix/spinner-loading-skeleton
+- **Files:** chla-ios/CHLA-iOS/Views/ProviderListView.swift
+- **Problem:** The Resources tab attaches its full-screen gradient background to the content Group; while loading, the Group collapsed to the intrinsic size of the spinner VStack, so the 300pt indigo gradient painted as a floating lavender slab around the spinner. Every re-search also replaced the visible list with that spinner.
+- **Fix:** Content now fills the screen so the background paints edge-to-edge; the bare spinner is replaced with pulsing skeleton provider cards (static under Reduce Motion, VoiceOver announces the loading label); skeletons show only until the first results arrive so refreshes keep the current list; the loading-to-list swap crossfades over 200ms.
+
 ### 2026-08-10 — Header-aware provider CSV import plus cleaned dataset
 - **Branch:** fix/csv-import-absent-columns
 - **Files:** maplocation/locations/management/commands/import_csv_providers.py, maplocation/locations/tests/test_import_csv_providers.py, docs/data/providers_complete_export_cleaned.csv

--- a/chla-ios/CHLA-iOS/Views/ProviderListView.swift
+++ b/chla-ios/CHLA-iOS/Views/ProviderListView.swift
@@ -20,6 +20,7 @@ struct ProviderListView: View {
     @State private var searchScope: SearchScope = .all
     @State private var searchSuggestions: [String] = []
     @State private var selectedProvider: Provider?
+    @State private var hasLoadedOnce = false
 
     enum SortOption: String, CaseIterable {
         case distance = "Distance"
@@ -72,7 +73,7 @@ struct ProviderListView: View {
     var body: some View {
         NavigationStack {
             Group {
-                if providerStore.isLoading {
+                if providerStore.providers.isEmpty && (providerStore.isLoading || !hasLoadedOnce) {
                     loadingView
                 } else if providerStore.providers.isEmpty {
                     emptyView
@@ -80,6 +81,11 @@ struct ProviderListView: View {
                     providerList
                 }
             }
+            // Fill the screen so the page background below paints edge-to-edge
+            // even when the visible branch has a small intrinsic size.
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .animation(.easeOut(duration: 0.2), value: providerStore.isLoading)
+            .animation(.easeOut(duration: 0.2), value: providerStore.providers.isEmpty)
             .background {
                 ZStack(alignment: .top) {
                     Color(.systemGroupedBackground)
@@ -248,12 +254,18 @@ struct ProviderListView: View {
     // MARK: - Subviews
 
     private var loadingView: some View {
-        VStack(spacing: 16) {
-            ProgressView()
-                .scaleEffect(1.5)
-            Text(L10n.Resources.loading)
-                .foregroundStyle(.secondary)
+        ScrollView {
+            VStack(spacing: 16) {
+                ForEach(0..<5, id: \.self) { _ in
+                    ProviderCardSkeleton()
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
         }
+        .scrollDisabled(true)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(L10n.Resources.loading)
     }
 
     private var emptyView: some View {
@@ -389,6 +401,7 @@ struct ProviderListView: View {
                 location: coordinate,
                 filters: appState.searchFilters
             )
+        hasLoadedOnce = true
     }
 
     private func refreshProviders() async {
@@ -551,6 +564,71 @@ struct ProviderCardView: View {
         therapy
             .replacingOccurrences(of: " therapy", with: "")
             .replacingOccurrences(of: "Parent child interaction therapy/parent training behavior management", with: "Parent Training")
+    }
+}
+
+// MARK: - Provider Card Skeleton (loading placeholder)
+
+private struct ProviderCardSkeleton: View {
+    @State private var pulsing = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 8) {
+                    RoundedRectangle(cornerRadius: 6)
+                        .frame(width: 190, height: 16)
+                    Capsule()
+                        .frame(width: 96, height: 22)
+                }
+
+                Spacer()
+
+                RoundedRectangle(cornerRadius: 12)
+                    .frame(width: 48, height: 54)
+            }
+
+            RoundedRectangle(cornerRadius: 6)
+                .frame(width: 225, height: 12)
+
+            HStack(spacing: 6) {
+                Capsule().frame(width: 68, height: 24)
+                Capsule().frame(width: 88, height: 24)
+                Capsule().frame(width: 56, height: 24)
+            }
+
+            HStack {
+                RoundedRectangle(cornerRadius: 6)
+                    .frame(width: 130, height: 12)
+                Spacer()
+                Capsule().frame(width: 64, height: 20)
+            }
+        }
+        .foregroundStyle(Color(.systemFill))
+        .opacity(pulsing ? 0.45 : 1)
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background {
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.secondarySystemGroupedBackground))
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(
+                    LinearGradient(
+                        colors: [.white.opacity(0.3), .black.opacity(0.05)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 0.5
+                )
+        }
+        .shadow(color: .black.opacity(0.06), radius: 12, y: 6)
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
+                pulsing = true
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- The Resources tab painted its full-screen gradient background on the content `Group`; while loading, the Group collapsed to the spinner's intrinsic size, so the 300pt indigo gradient rendered as a floating lavender slab around the spinner.
- Content now fills the screen so the background always paints edge-to-edge, and the bare spinner is replaced with pulsing skeleton provider cards that mirror the real card layout (static under Reduce Motion; VoiceOver announces the loading label).
- The skeleton only shows before the first results arrive, so pull-to-refresh and filter re-searches keep the current list on screen instead of blanking back to a spinner; the loading-to-list swap crossfades over 200ms.

## Test plan
- [x] `xcodebuild -scheme CHLA-iOS -destination 'generic/platform=iOS Simulator' build` passes (only pre-existing TextToSpeech deprecation warnings)
- [ ] Visual check on device: cold launch of the Resources tab shows skeleton cards on the normal page background
