### PR TITLE
chore(ios): tag releases automatically after upload

### DIFF
--- a/FIXES.md
+++ b/FIXES.md
@@ -13,6 +13,12 @@ Format:
 
 ---
 
+### 2026-08-13 — release.sh tags each upload
+- **Branch:** chore/release-tagging
+- **Files:** chla-ios/scripts/release.sh
+- **Problem:** Releases were never pinned in git (1.4.0 and 1.4.1 shipped untagged; v1.4.1/v1.4.2 were back-tagged by hand today), so the archived source of an upload was not recoverable from the repo.
+- **Fix:** After a successful upload, release.sh creates an annotated v{VERSION} tag and pushes it - only when the working tree is clean, since a dirty tree would not describe the archived source. Existing tags are never moved.
+
 ### 2026-08-13 — TestFlight uploads broadcast to Slack; 1.4.2 version bump
 - **Branch:** feat/onboarding-diagnosis
 - **Files:** chla-ios/scripts/release.sh, chla-ios/CHLA-iOS/Resources/Info.plist, chla-ios/CHLA-iOS.xcodeproj/project.pbxproj

--- a/chla-ios/scripts/release.sh
+++ b/chla-ios/scripts/release.sh
@@ -104,3 +104,19 @@ if [ -n "$SLACK_TOKEN" ]; then
 else
     echo "== Slack notify skipped (no bot token found)"
 fi
+
+# Pin the upload to an annotated git tag (vVERSION) when the tree is clean.
+# A dirty tree means the tag would not describe the archived source - skip.
+if [ -z "$(git status --porcelain 2>/dev/null)" ]; then
+    TAG="v$VERSION"
+    if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+        echo "== Tag $TAG already exists; leaving it in place"
+    else
+        git tag -a "$TAG" -m "KiNDD iOS $VERSION ($BUILD) uploaded to App Store Connect"
+        git push -q origin "$TAG" \
+            && echo "== Tagged $TAG and pushed" \
+            || echo "== Tagged $TAG locally; push failed"
+    fi
+else
+    echo "== Git tag skipped (working tree dirty)"
+fi


### PR DESCRIPTION
release.sh pins each successful upload to an annotated v{VERSION} tag and pushes it, only when the tree is clean (a dirty tree would not describe the archived source). Existing tags are never moved. v1.4.1 and v1.4.2 were back-tagged by hand today; this makes future ones automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPLMZkUwXSMEnG3PQqdg1o